### PR TITLE
参照画面のuiを変更

### DIFF
--- a/app/views/ideas/_idea.html.erb
+++ b/app/views/ideas/_idea.html.erb
@@ -1,22 +1,16 @@
-<div id="<%= dom_id idea %>">
-  <p>
-    <strong>Title:</strong>
-    <%= idea.title %>
-  </p>
-
-  <p>
-    <strong>Description:</strong>
-    <%= idea.description %>
-  </p>
-
-  <p>
-    <strong>Picture:</strong>
-    <%= image_tag(idea.picture_url, width: '600px') if idea.picture.present? %>
-  </p>
-
-  <p>
-    <strong>Published at:</strong>
-    <%= idea.published_at %>
-  </p>
-
+<div id="<%= dom_id idea %>" class="row">
+  <div class="col-md-6 my-3">
+    <%= image_tag(idea.picture_url, width: '100px') if idea.picture.present? %>
+  </div>
+  <div class="col-md-6 my-3">
+    <h1>
+      <%= idea.title %>
+    </h1>
+    <time class="badge rounded-pill bg-info text-dark">
+      <%= idea.published_at %>
+    </time>
+    <p class="my-4">
+      <%= idea.description %>
+    </p>
+  </div>
 </div>

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -2,9 +2,8 @@
 
 <%= render @idea %>
 
-<div>
-  <%= link_to "Edit this idea", edit_idea_path(@idea) %> |
-  <%= link_to "Back to ideas", ideas_path %>
+<div class="btn-toolbar">
+  <%= link_to "Edit this idea", edit_idea_path(@idea), class: "btn btn-info" %>
 
-  <%= button_to "Destroy this idea", @idea, method: :delete %>
+  <%= button_to "Destroy this idea", @idea, method: :delete, class: "btn btn-danger ms-3" %>
 </div>


### PR DESCRIPTION
# 実装内容

- `画像`と`タイトル・年月日・内容`を横並びに。uiも変更
- ボタンの`Back to ideas`は削除 (ナビゲーションに同じ機能のボタンがあるため)。各ボタンのuiを変更

<img width="777" alt="スクリーンショット 2024-12-21 17 41 56" src="https://github.com/user-attachments/assets/d7b9468a-69c4-4216-94c0-cc7e2959893b" />
