### PR TITLE
ログイン済みユーザーに日記の投稿・編集・削除を限定し、未ログインユーザーは閲覧のみ可能にする

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -1,4 +1,5 @@
 class IdeasController < ApplicationController
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
   before_action :set_idea, only: %i[ show edit update destroy ]
 
   # GET /ideas or /ideas.json

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -1,7 +1,7 @@
 <%= render @idea %>
-
+<% if user_signed_in? %>
 <div class="btn-toolbar">
   <%= link_to "Edit this idea", edit_idea_path(@idea), class: "btn btn-info" %>
-
   <%= button_to "Destroy this idea", @idea, method: :delete, class: "btn btn-danger ms-3" %>
 </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,11 @@
           </li>
         </ul>
         <span class="navbar-text pull-right">
+          <% if user_signed_in? %>
           <%= button_to "Logout", destroy_user_session_path, method: :delete, data: { turbo:false }, class: "btn btn-link" %>
+          <% else %>
+          <%= link_to "Login", new_user_session_path, class: "btn btn-link" %>
+          <% end %>
         </span>
       </div>
     </div>


### PR DESCRIPTION
ログイン中はナビゲーションに`メールアドレス`と`Logout`を表示させる。

![スクリーンショット 2024-12-24 17 22 14](https://github.com/user-attachments/assets/23073a79-a350-4af5-bc4e-5a96f84c30ac)


未ログイン状態だと表示が`Login`に変わる。
![スクリーンショット 2024-12-24 17 42 37](https://github.com/user-attachments/assets/4df47ae7-f9af-4db2-819a-c78e31195684)


未ログインユーザーが詳細ページを閲覧した時に、`編集ボタン`と`削除ボタン`は表示されない
![スクリーンショット 2024-12-24 17 40 02](https://github.com/user-attachments/assets/8d1ead19-0c55-4505-ac84-d85ffab3a0a2)

ログインユーザーが詳細ページを閲覧したときは、`編集ボタン`と`削除ボタン`が表示される
![スクリーンショット 2024-12-24 17 41 52](https://github.com/user-attachments/assets/b7b71b4d-bae4-436d-91f2-c8d6ac2395c9)

